### PR TITLE
feat: add size prop support for Icon component

### DIFF
--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -25,10 +25,13 @@ export interface IconProps extends React.SVGProps<SVGElement> {
   /** Svg fill color */
   fill?: string;
 
+  /** Icon size (sets both width and height) */
+  size?: number | string;
+
   /** Svg width */
   width?: number | string;
 
-  /** Svg width */
+  /** Svg height */
   height?: number | string;
 }
 
@@ -54,8 +57,9 @@ const Icon = React.forwardRef<SVGElement, IconProps>(
       rotate,
       children,
       viewBox,
-      width = '1em',
-      height = '1em',
+      size,
+      width,
+      height,
       style,
       ...rest
     } = props;
@@ -73,9 +77,13 @@ const Icon = React.forwardRef<SVGElement, IconProps>(
 
     useInsertStyles();
 
+    // size prop takes precedence over width/height if provided
+    const iconWidth = size ?? width ?? '1em';
+    const iconHeight = size ?? height ?? '1em';
+
     const svgProps = filterProps({
-      width,
-      height,
+      width: iconWidth,
+      height: iconHeight,
       fill,
       viewBox,
       className: classes,

--- a/storybook/CustomIcon.stories.tsx
+++ b/storybook/CustomIcon.stories.tsx
@@ -41,6 +41,53 @@ const meta: Meta<typeof Icon> = {
     width: '2em',
     height: '2em'
   },
+  argTypes: {
+    size: {
+      control: { type: 'text' },
+      description: 'Icon size (sets both width and height)',
+      table: {
+        type: { summary: 'number | string' },
+        defaultValue: { summary: '1em' }
+      }
+    },
+    width: {
+      control: { type: 'text' },
+      description: 'Icon width',
+      table: {
+        type: { summary: 'number | string' },
+        defaultValue: { summary: '1em' }
+      }
+    },
+    height: {
+      control: { type: 'text' },
+      description: 'Icon height',
+      table: {
+        type: { summary: 'number | string' },
+        defaultValue: { summary: '1em' }
+      }
+    },
+    spin: {
+      control: 'boolean',
+      description: 'Dynamic rotation icon'
+    },
+    pulse: {
+      control: 'boolean',
+      description: 'Use pulse to have it rotate with 8 steps'
+    },
+    rotate: {
+      control: { type: 'number', min: 0, max: 360, step: 15 },
+      description: 'Rotate the icon (in degrees)'
+    },
+    flip: {
+      control: { type: 'select' },
+      options: [undefined, 'horizontal', 'vertical'],
+      description: 'Flip the icon'
+    },
+    fill: {
+      control: 'color',
+      description: 'SVG fill color'
+    }
+  },
   tags: ['autodocs']
 };
 
@@ -56,5 +103,19 @@ export const HeartIcon: Story = {
 export const PeopleFoldIcon: Story = {
   args: {
     as: PeopleFoldSvg
+  }
+};
+
+export const HeartIconWithSize: Story = {
+  args: {
+    as: HeartSvg,
+    size: 64
+  }
+};
+
+export const PeopleFoldIconWithSize: Story = {
+  args: {
+    as: PeopleFoldSvg,
+    size: '5em'
   }
 };

--- a/storybook/Icon.stories.tsx
+++ b/storybook/Icon.stories.tsx
@@ -12,6 +12,53 @@ const meta: Meta<typeof Icon> = {
     width: '2em',
     height: '2em'
   },
+  argTypes: {
+    size: {
+      control: { type: 'text' },
+      description: 'Icon size (sets both width and height)',
+      table: {
+        type: { summary: 'number | string' },
+        defaultValue: { summary: '1em' }
+      }
+    },
+    width: {
+      control: { type: 'text' },
+      description: 'Icon width',
+      table: {
+        type: { summary: 'number | string' },
+        defaultValue: { summary: '1em' }
+      }
+    },
+    height: {
+      control: { type: 'text' },
+      description: 'Icon height',
+      table: {
+        type: { summary: 'number | string' },
+        defaultValue: { summary: '1em' }
+      }
+    },
+    spin: {
+      control: 'boolean',
+      description: 'Dynamic rotation icon'
+    },
+    pulse: {
+      control: 'boolean',
+      description: 'Use pulse to have it rotate with 8 steps'
+    },
+    rotate: {
+      control: { type: 'number', min: 0, max: 360, step: 15 },
+      description: 'Rotate the icon (in degrees)'
+    },
+    flip: {
+      control: { type: 'select' },
+      options: [undefined, 'horizontal', 'vertical'],
+      description: 'Flip the icon'
+    },
+    fill: {
+      control: 'color',
+      description: 'SVG fill color'
+    }
+  },
   tags: ['autodocs']
 };
 
@@ -43,6 +90,18 @@ export const Flip: Story = {
 };
 
 export const Size: Story = {
+  args: {
+    size: 200
+  }
+};
+
+export const SizeWithString: Story = {
+  args: {
+    size: '4em'
+  }
+};
+
+export const CustomWidthHeight: Story = {
   args: {
     width: 200,
     height: 200

--- a/test/Icon.cy.tsx
+++ b/test/Icon.cy.tsx
@@ -105,6 +105,39 @@ it('Should be setting width and height', () => {
   cy.get('svg').should('have.attr', 'height', '25');
 });
 
+it('Should support size prop with number', () => {
+  cy.mount(
+    <Icon size={24}>
+      <IconCheckPath />
+    </Icon>
+  );
+
+  cy.get('svg').should('have.attr', 'width', '24');
+  cy.get('svg').should('have.attr', 'height', '24');
+});
+
+it('Should support size prop with string', () => {
+  cy.mount(
+    <Icon size="2em">
+      <IconCheckPath />
+    </Icon>
+  );
+
+  cy.get('svg').should('have.attr', 'width', '2em');
+  cy.get('svg').should('have.attr', 'height', '2em');
+});
+
+it('Should size prop take precedence over width and height', () => {
+  cy.mount(
+    <Icon size={32} width={16} height={20}>
+      <IconCheckPath />
+    </Icon>
+  );
+
+  cy.get('svg').should('have.attr', 'width', '32');
+  cy.get('svg').should('have.attr', 'height', '32');
+});
+
 // This test case is not working
 it.skip('Should can set tabIndex', () => {
   cy.mount(<Icon tabIndex={999} onClick={() => void 0} as={IconCheck} />);


### PR DESCRIPTION
This pull request introduces a new `size` prop to the `Icon` component, allowing users to easily set both the width and height of SVG icons with a single value. The `size` prop takes precedence over the individual `width` and `height` props. The change is fully documented and tested, with updates to Storybook stories and tests to demonstrate and verify the new behavior.

**Icon component enhancements:**

* Added a `size` prop to the `IconProps` interface, allowing users to set both width and height of the icon with a single value. The `size` prop takes precedence over `width` and `height` if provided. (`src/Icon.tsx`) [[1]](diffhunk://#diff-a9b24fc3c5bed8497074b26eacf41c83130ee66ecde1b037a82cc154459d484aR28-R34) [[2]](diffhunk://#diff-a9b24fc3c5bed8497074b26eacf41c83130ee66ecde1b037a82cc154459d484aL57-R62) [[3]](diffhunk://#diff-a9b24fc3c5bed8497074b26eacf41c83130ee66ecde1b037a82cc154459d484aR80-R86)

**Storybook updates:**

* Updated `argTypes` in both `CustomIcon.stories.tsx` and `Icon.stories.tsx` to document and control the new `size` prop, as well as existing width, height, and other props. Added new stories demonstrating the usage of the `size` prop with both numbers and strings. (`storybook/CustomIcon.stories.tsx`, `storybook/Icon.stories.tsx`) [[1]](diffhunk://#diff-20182f1972ace25e9c64eeed40ab03922cfb83fe6a731b48bb0962b4b6be791eR44-R90) [[2]](diffhunk://#diff-20182f1972ace25e9c64eeed40ab03922cfb83fe6a731b48bb0962b4b6be791eR108-R121) [[3]](diffhunk://#diff-f049f2bc48f1a2ca0f74f807da6be33acee61a8a95b007c954d65d95f27e0a26R15-R61) [[4]](diffhunk://#diff-f049f2bc48f1a2ca0f74f807da6be33acee61a8a95b007c954d65d95f27e0a26R93-R104)

**Testing improvements:**

* Added comprehensive tests to ensure the `size` prop works as intended, including precedence over `width` and `height`, and support for both number and string values. (`test/Icon.cy.tsx`)