### PR TITLE
fix: mark CSS files as side effects to prevent tree-shaking (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
     "typescript": "^5.6.3",
     "vite": "^5.4.9"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "*.css",
+    "dist/css/*"
+  ]
 }


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite-icons/issues/21